### PR TITLE
Adding more configurations to livy interpreter

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -23,7 +23,7 @@ Additional requirements for the Livy interpreter are:
  * Livy server.
 
 ### Configuration
-We added some common configurations for spark, and you can set any configuration you want which should start with `spark.`
+We added some common configurations for spark, and you can set any configuration you want which should start with `livy.spark.`
 <table class="table-configuration">
   <tr>
     <th>Property</th>
@@ -31,7 +31,7 @@ We added some common configurations for spark, and you can set any configuration
     <th>Description</th>
   </tr>
   <tr>
-      <td>spark.master</td>
+      <td>livy.spark.master</td>
       <td>local[*]</td>
       <td>Spark master uri. ex) spark://masterhost:7077</td>
     </tr>
@@ -46,22 +46,22 @@ We added some common configurations for spark, and you can set any configuration
     <td>Max number of SparkSQL result to display.</td>
   </tr>
     <tr>
-    <td>spark.driver.cores</td>
+    <td>livy.spark.driver.cores</td>
     <td>1</td>
     <td>Driver cores. ex) 1, 2.</td>
   </tr>
     <tr>
-    <td>spark.driver.memory</td>
+    <td>livy.spark.driver.memory</td>
     <td>512m</td>
     <td>Driver memory. ex) 512m, 32g.</td>
   </tr>
     <tr>
-    <td>spark.executor.instances</td>
+    <td>livy.spark.executor.instances</td>
     <td>3</td>
     <td>Executor instances. ex) 1, 4.</td>
   </tr>
     <tr>
-    <td>spark.executor.cores</td>
+    <td>livy.spark.executor.cores</td>
     <td>1</td>
     <td>Max number of SparkSQL result to display.</td>
   </tr>

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -44,6 +44,26 @@ Additional requirements for the Livy interpreter are:
     <td>1000</td>
     <td>Max number of SparkSQL result to display.</td>
   </tr>
+    <tr>
+    <td>spark.driver.cores</td>
+    <td>1</td>
+    <td>Driver cores. ex) 1, 2.</td>
+  </tr>
+    <tr>
+    <td>spark.driver.memory</td>
+    <td>512m</td>
+    <td>Driver memory. ex) 512m, 32g.</td>
+  </tr>
+    <tr>
+    <td>spark.executor.instances</td>
+    <td>3</td>
+    <td>Executor instances. ex) 1, 4.</td>
+  </tr>
+    <tr>
+    <td>spark.executor.cores</td>
+    <td>1</td>
+    <td>Max number of SparkSQL result to display.</td>
+  </tr>
 </table>
 
 
@@ -105,3 +125,6 @@ The session would have timed out, you may need to restart the interpreter.
 > Blacklisted configuration values in session config: spark.master
 
 edit `conf/spark-blacklist.conf` file in livy server and comment out `#spark.master` line.
+
+if you choose to work on livy https://github.com/cloudera/hue/tree/master/apps/spark/java,
+copy `spark-user-configurable-options.template` to `spark-user-configurable-options.conf` file in livy server and comment out `#spark.master` 

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -51,23 +51,53 @@ Example: `spark.master` to `livy.spark.master`
   </tr>
     <tr>
     <td>livy.spark.driver.cores</td>
-    <td>1</td>
+    <td></td>
     <td>Driver cores. ex) 1, 2.</td>
   </tr>
     <tr>
     <td>livy.spark.driver.memory</td>
-    <td>512m</td>
+    <td></td>
     <td>Driver memory. ex) 512m, 32g.</td>
   </tr>
     <tr>
     <td>livy.spark.executor.instances</td>
-    <td>3</td>
+    <td></td>
     <td>Executor instances. ex) 1, 4.</td>
   </tr>
     <tr>
     <td>livy.spark.executor.cores</td>
-    <td>1</td>
-    <td>Max number of SparkSQL result to display.</td>
+    <td></td>
+    <td>Num cores per executor. ex) 1, 4.</td>
+  </tr>
+  <tr>
+    <td>livy.spark.executor.memory</td>
+    <td></td>
+    <td>Executor memory per worker instance. ex) 512m, 32g.</td>
+  </tr>
+  <tr>
+    <td>livy.spark.dynamicAllocation.enabled</td>
+    <td></td>
+    <td>Use dynamic resource allocation. ex) True, False.</td>
+  </tr>
+  <tr>
+    <td>livy.spark.dynamicAllocation.cachedExecutorIdleTimeout</td>
+    <td></td>
+    <td>Remove an executor which has cached data blocks.</td>
+  </tr>
+  <tr>
+    <td>livy.spark.dynamicAllocation.minExecutors</td>
+    <td></td>
+    <td>Lower bound for the number of executors.</td>
+  </tr>
+  <tr>
+    <td>livy.spark.dynamicAllocation.initialExecutors</td>
+    <td></td>
+    <td>Initial number of executors to run.</td>
+  </tr>
+  <tr>
+    <td>livy.spark.dynamicAllocation.maxExecutors</td>
+    <td></td>
+    <td>Upper bound for the number of executors.</td>
   </tr>
 </table>
 

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -23,7 +23,11 @@ Additional requirements for the Livy interpreter are:
  * Livy server.
 
 ### Configuration
-We added some common configurations for spark, and you can set any configuration you want which should start with `livy.spark.`
+We added some common configurations for spark, and you can set any configuration you want.
+This link contains all spark configurations: http://spark.apache.org/docs/latest/configuration.html#available-properties.
+And instead of starting property with `spark.` it should be replaced with `livy.spark.`.
+Example: `spark.master` to `livy.spark.master`
+
 <table class="table-configuration">
   <tr>
     <th>Property</th>

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -23,6 +23,7 @@ Additional requirements for the Livy interpreter are:
  * Livy server.
 
 ### Configuration
+We added some common configurations for spark, and you can set any configuration you want which should start with `spark.`
 <table class="table-configuration">
   <tr>
     <th>Property</th>

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -30,7 +30,7 @@ Additional requirements for the Livy interpreter are:
     <th>Description</th>
   </tr>
   <tr>
-      <td>zeppelin.livy.master</td>
+      <td>spark.master</td>
       <td>local[*]</td>
       <td>Spark master uri. ex) spark://masterhost:7077</td>
     </tr>
@@ -126,5 +126,5 @@ The session would have timed out, you may need to restart the interpreter.
 
 edit `conf/spark-blacklist.conf` file in livy server and comment out `#spark.master` line.
 
-if you choose to work on livy https://github.com/cloudera/hue/tree/master/apps/spark/java,
+if you choose to work on livy in `apps/spark/java` directory in https://github.com/cloudera/hue ,
 copy `spark-user-configurable-options.template` to `spark-user-configurable-options.conf` file in livy server and comment out `#spark.master` 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.livy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -40,7 +41,9 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 
@@ -62,29 +65,11 @@ public class LivyHelper {
     try {
       Map<String, String> conf = new HashMap<String, String>();
       
-      conf.put("spark.master", property.getProperty("zeppelin.livy.master"));
-      
-      conf.put("spark.driver.cores", property.getProperty("spark.driver.cores"));
-      conf.put("spark.executor.cores", property.getProperty("spark.executor.cores"));
-      conf.put("spark.driver.memory", property.getProperty("spark.driver.memory"));
-      conf.put("spark.executor.memory", property.getProperty("spark.executor.memory"));
-
-      if (!property.getProperty("spark.dynamicAllocation.enabled").equals("true")) {
-        conf.put("spark.executor.instances", property.getProperty("spark.executor.instances"));
-      }
-
-      if (property.getProperty("spark.dynamicAllocation.enabled").equals("true")) {
-        conf.put("spark.dynamicAllocation.enabled",
-            property.getProperty("spark.dynamicAllocation.enabled"));
-        conf.put("spark.shuffle.service.enabled", "true");
-        conf.put("spark.dynamicAllocation.cachedExecutorIdleTimeout",
-            property.getProperty("spark.dynamicAllocation.cachedExecutorIdleTimeout"));
-        conf.put("spark.dynamicAllocation.minExecutors",
-            property.getProperty("spark.dynamicAllocation.minExecutors"));
-        conf.put("spark.dynamicAllocation.initialExecutors",
-            property.getProperty("spark.dynamicAllocation.initialExecutors"));
-        conf.put("spark.dynamicAllocation.maxExecutors",
-            property.getProperty("spark.dynamicAllocation.maxExecutors"));
+      Iterator<Entry<Object, Object>> it = property.entrySet().iterator();
+      while (it.hasNext()) {
+        Entry<Object, Object> pair = it.next();
+        if (pair.getKey().toString().startsWith("spark.") && !pair.getValue().toString().isEmpty())
+          conf.put(pair.getKey().toString(), pair.getValue().toString());
       }
 
       String confData = gson.toJson(conf);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -68,8 +68,9 @@ public class LivyHelper {
       Iterator<Entry<Object, Object>> it = property.entrySet().iterator();
       while (it.hasNext()) {
         Entry<Object, Object> pair = it.next();
-        if (pair.getKey().toString().startsWith("spark.") && !pair.getValue().toString().isEmpty())
-          conf.put(pair.getKey().toString(), pair.getValue().toString());
+        if (pair.getKey().toString().startsWith("livy.spark.") && 
+            !pair.getValue().toString().isEmpty())
+          conf.put(pair.getKey().toString().substring(5), pair.getValue().toString());
       }
 
       String confData = gson.toJson(conf);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -46,6 +46,21 @@ public class LivySparkInterpreter extends Interpreter {
         new InterpreterPropertyBuilder()
             .add("zeppelin.livy.url", DEFAULT_URL, "The URL for Livy Server.")
             .add("zeppelin.livy.master", LOCAL, "Spark master uri. ex) spark://masterhost:7077")
+            .add("spark.driver.cores", "1", "Driver cores. ex) 1, 2")
+            .add("spark.driver.memory", "512m", "Driver memory. ex) 512m, 32g")
+            .add("spark.executor.instances", "3", "Executor instances. ex) 1, 4")
+            .add("spark.executor.cores", "1", "Num cores per executor. ex) 1, 4")
+            .add("spark.executor.memory", "512m", 
+                 "Executor memory per worker instance. ex) 512m, 32g")
+            .add("spark.dynamicAllocation.enabled", "false", "Use dynamic resource allocation")
+            .add("spark.dynamicAllocation.cachedExecutorIdleTimeout", "120s", 
+                 "Remove an executor which has cached data blocks")
+            .add("spark.dynamicAllocation.minExecutors", "0", 
+                 "Lower bound for the number of executors if dynamic allocation is enabled. ")
+            .add("spark.dynamicAllocation.initialExecutors", "1", 
+                 "Initial number of executors to run if dynamic allocation is enabled. ")
+            .add("spark.dynamicAllocation.maxExecutors", "10", 
+                 "Upper bound for the number of executors if dynamic allocation is enabled. ")
             .build()
     );
   }

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -45,7 +45,7 @@ public class LivySparkInterpreter extends Interpreter {
         LivySparkInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
             .add("zeppelin.livy.url", DEFAULT_URL, "The URL for Livy Server.")
-            .add("zeppelin.livy.master", LOCAL, "Spark master uri. ex) spark://masterhost:7077")
+            .add("spark.master", LOCAL, "Spark master uri. ex) spark://masterhost:7077")
             .add("spark.driver.cores", "1", "Driver cores. ex) 1, 2")
             .add("spark.driver.memory", "512m", "Driver memory. ex) 512m, 32g")
             .add("spark.executor.instances", "3", "Executor instances. ex) 1, 4")

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -45,21 +45,21 @@ public class LivySparkInterpreter extends Interpreter {
         LivySparkInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
             .add("zeppelin.livy.url", DEFAULT_URL, "The URL for Livy Server.")
-            .add("spark.master", LOCAL, "Spark master uri. ex) spark://masterhost:7077")
-            .add("spark.driver.cores", "", "Driver cores. ex) 1, 2")
-            .add("spark.driver.memory", "", "Driver memory. ex) 512m, 32g")
-            .add("spark.executor.instances", "", "Executor instances. ex) 1, 4")
-            .add("spark.executor.cores", "", "Num cores per executor. ex) 1, 4")
-            .add("spark.executor.memory", "", 
+            .add("livy.spark.master", LOCAL, "Spark master uri. ex) spark://masterhost:7077")
+            .add("livy.spark.driver.cores", "", "Driver cores. ex) 1, 2")
+            .add("livy.spark.driver.memory", "", "Driver memory. ex) 512m, 32g")
+            .add("livy.spark.executor.instances", "", "Executor instances. ex) 1, 4")
+            .add("livy.spark.executor.cores", "", "Num cores per executor. ex) 1, 4")
+            .add("livy.spark.executor.memory", "", 
                  "Executor memory per worker instance. ex) 512m, 32g")
-            .add("spark.dynamicAllocation.enabled", "", "Use dynamic resource allocation")
-            .add("spark.dynamicAllocation.cachedExecutorIdleTimeout", "", 
+            .add("livy.spark.dynamicAllocation.enabled", "", "Use dynamic resource allocation")
+            .add("livy.spark.dynamicAllocation.cachedExecutorIdleTimeout", "", 
                  "Remove an executor which has cached data blocks")
-            .add("spark.dynamicAllocation.minExecutors", "", 
+            .add("livy.spark.dynamicAllocation.minExecutors", "", 
                  "Lower bound for the number of executors if dynamic allocation is enabled. ")
-            .add("spark.dynamicAllocation.initialExecutors", "", 
+            .add("livy.spark.dynamicAllocation.initialExecutors", "", 
                  "Initial number of executors to run if dynamic allocation is enabled. ")
-            .add("spark.dynamicAllocation.maxExecutors", "", 
+            .add("livy.spark.dynamicAllocation.maxExecutors", "", 
                  "Upper bound for the number of executors if dynamic allocation is enabled. ")
             .build()
     );

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -46,20 +46,20 @@ public class LivySparkInterpreter extends Interpreter {
         new InterpreterPropertyBuilder()
             .add("zeppelin.livy.url", DEFAULT_URL, "The URL for Livy Server.")
             .add("spark.master", LOCAL, "Spark master uri. ex) spark://masterhost:7077")
-            .add("spark.driver.cores", "1", "Driver cores. ex) 1, 2")
-            .add("spark.driver.memory", "512m", "Driver memory. ex) 512m, 32g")
-            .add("spark.executor.instances", "3", "Executor instances. ex) 1, 4")
-            .add("spark.executor.cores", "1", "Num cores per executor. ex) 1, 4")
-            .add("spark.executor.memory", "512m", 
+            .add("spark.driver.cores", "", "Driver cores. ex) 1, 2")
+            .add("spark.driver.memory", "", "Driver memory. ex) 512m, 32g")
+            .add("spark.executor.instances", "", "Executor instances. ex) 1, 4")
+            .add("spark.executor.cores", "", "Num cores per executor. ex) 1, 4")
+            .add("spark.executor.memory", "", 
                  "Executor memory per worker instance. ex) 512m, 32g")
-            .add("spark.dynamicAllocation.enabled", "false", "Use dynamic resource allocation")
-            .add("spark.dynamicAllocation.cachedExecutorIdleTimeout", "120s", 
+            .add("spark.dynamicAllocation.enabled", "", "Use dynamic resource allocation")
+            .add("spark.dynamicAllocation.cachedExecutorIdleTimeout", "", 
                  "Remove an executor which has cached data blocks")
-            .add("spark.dynamicAllocation.minExecutors", "0", 
+            .add("spark.dynamicAllocation.minExecutors", "", 
                  "Lower bound for the number of executors if dynamic allocation is enabled. ")
-            .add("spark.dynamicAllocation.initialExecutors", "1", 
+            .add("spark.dynamicAllocation.initialExecutors", "", 
                  "Initial number of executors to run if dynamic allocation is enabled. ")
-            .add("spark.dynamicAllocation.maxExecutors", "10", 
+            .add("spark.dynamicAllocation.maxExecutors", "", 
                  "Upper bound for the number of executors if dynamic allocation is enabled. ")
             .build()
     );


### PR DESCRIPTION
### What is this PR for?

Extending the livy interpreter to allow manipulation in the configurations of Spark from zeppelin web ui.
### What type of PR is it?

Improvement
### Todos
- [Test case ] - Task
- [Documentation ] - Task
### What is the Jira issue?
- [ZEPPELIN-935]
### How should this be tested?
- Run livy server in yarn mode or local mode
- Start the Zeppelin and go to interpreter page, create livy interpreter with supported configurations
### Screenshots (if appropriate)

![](http://s33.postimg.org/rukcyp1in/Screenshot_from_2016_06_01_11_55_37.png)
![](http://s33.postimg.org/a8chtwtf3/Screenshot_from_2016_06_01_11_23_59.png)
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? yes
