### PR TITLE
Adding extra libraries to livy

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -30,7 +30,7 @@ We added some common configurations for spark, and you can set any configuration
 This link contains all spark configurations: http://spark.apache.org/docs/latest/configuration.html#available-properties.
 And instead of starting property with `spark.` it should be replaced with `livy.spark.`.
 Example: `spark.master` to `livy.spark.master`
-
+  
 <table class="table-configuration">
   <tr>
     <th>Property</th>
@@ -102,8 +102,41 @@ Example: `spark.master` to `livy.spark.master`
     <td></td>
     <td>Upper bound for the number of executors.</td>
   </tr>
+    <tr>
+      <td>livy.spark.executor.extraClassPath</td>
+      <td></td>
+      <td>Adding extra libraries to the executors</td>
+    </tr>
+  <tr>
+      <td>livy.spark.driver.extraClassPath</td>
+      <td></td>
+      <td>Adding extra libraries to the driver</td>
+  </tr>
 </table>
 
+## Adding External libraries
+You should put the libraries manually on the livy server and then set the paths of the libraries to those properties `livy.spark.executor.extraClassPath` and `livy.spark.driver.extraClassPath`
+
+Example
+
+<table class="table-configuration">
+  <tr>
+    <th>Property</th>
+    <th>Default</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+      <td>livy.spark.executor.extraClassPath</td>
+      <td>path/to/jar1.jar:path/to/jar2.jar</td>
+      <td>Adding extra libraries to the executors</td>
+    </tr>
+  <tr>
+      <td>livy.spark.driver.extraClassPath</td>
+      <td>path/to/jar1.jar:path/to/jar2.jar</td>
+      <td>Adding extra libraries to the driver</td>
+  <tr>
+  </table>
+  
 ## How to use
 Basically, you can use
 

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -103,19 +103,14 @@ Example: `spark.master` to `livy.spark.master`
     <td>Upper bound for the number of executors.</td>
   </tr>
     <tr>
-      <td>livy.spark.executor.extraClassPath</td>
+      <td>livy.spark.jars.packages</td>
       <td></td>
-      <td>Adding extra libraries to the executors</td>
+      <td>Adding extra libraries to livy interpreter</td>
     </tr>
-  <tr>
-      <td>livy.spark.driver.extraClassPath</td>
-      <td></td>
-      <td>Adding extra libraries to the driver</td>
-  </tr>
 </table>
 
 ## Adding External libraries
-You should put the libraries manually on the livy server and then set the paths of the libraries to those properties `livy.spark.executor.extraClassPath` and `livy.spark.driver.extraClassPath`
+You can load dynamic library to livy interpreter by set `livy.spark.jars.packages` property to comma-separated list of maven coordinates of jars to include on the driver and executor classpaths. The format for the coordinates should be groupId:artifactId:version. 
 
 Example
 
@@ -126,15 +121,10 @@ Example
     <th>Description</th>
   </tr>
   <tr>
-      <td>livy.spark.executor.extraClassPath</td>
-      <td>path/to/jar1.jar:path/to/jar2.jar</td>
-      <td>Adding extra libraries to the executors</td>
+      <td>livy.spark.jars.packages</td>
+      <td>io.spray:spray-json_2.10:1.3.1</td>
+      <td>Adding extra libraries to livy interpreter</td>
     </tr>
-  <tr>
-      <td>livy.spark.driver.extraClassPath</td>
-      <td>path/to/jar1.jar:path/to/jar2.jar</td>
-      <td>Adding extra libraries to the driver</td>
-  <tr>
   </table>
   
 ## How to use

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -117,7 +117,7 @@ Example
 <table class="table-configuration">
   <tr>
     <th>Property</th>
-    <th>Default</th>
+    <th>Example</th>
     <th>Description</th>
   </tr>
   <tr>

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -82,15 +82,10 @@
         "defaultValue": "",
         "description": "Kerberos keytab to authenticate livy"
       },
-      "livy.spark.executor.extraClassPath": {
-        "propertyName": "livy.spark.executor.extraClassPath",
+      "livy.spark.jars.packages": {
+        "propertyName": "livy.spark.jars.packages",
         "defaultValue": "",
-        "description": "Adding extra libraries to the executors"
-      },
-      "livy.spark.driver.extraClassPath": {
-        "propertyName": "livy.spark.driver.extraClassPath",
-        "defaultValue": "",
-        "description": "Adding extra libraries to the driver"
+        "description": "Adding extra libraries to livy interpreter"
       }
     }
   },

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -81,6 +81,16 @@
         "propertyName": "zeppelin.livy.keytab",
         "defaultValue": "",
         "description": "Kerberos keytab to authenticate livy"
+      },
+      "livy.spark.executor.extraClassPath": {
+        "propertyName": "livy.spark.executor.extraClassPath",
+        "defaultValue": "",
+        "description": "Adding extra libraries to the executors"
+      },
+      "livy.spark.driver.extraClassPath": {
+        "propertyName": "livy.spark.driver.extraClassPath",
+        "defaultValue": "",
+        "description": "Adding extra libraries to the driver"
       }
     }
   },


### PR DESCRIPTION
### What is this PR for?

Adding extra libraries to livy interpreter which isn't exist by default.
### What type of PR is it?

[ Improvement ]
### Todos
- [Test case ] - Task
### What is the Jira issue?
-  [ZEPPELIN-1258]
### How should this be tested?
- Create new livy interpreter or modify the default.
- Set `livy.spark.driver.extraClassPath` and `livy.spark.executor.extraClassPath` to path of libraries.
### Screenshots (if appropriate)

![](https://s32.postimg.org/cxo94lzc5/livy_example_with_external_library.png)
![](https://s31.postimg.org/41gbe8hwr/add_Classpath_property_to_livy.png)
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? yes
